### PR TITLE
Replace unneeded new variable for deploy location

### DIFF
--- a/meta-senic/recipes-hub/hub-configuration/files/supervisor_bluenet.conf
+++ b/meta-senic/recipes-hub/hub-configuration/files/supervisor_bluenet.conf
@@ -2,7 +2,7 @@
 command = /usr/bin/bluenet -b hci0 -w wlan0 start -v -h http://%%IP:6543/-/ -a 'Senic Hub'
 autostart=false
 autorestart=true
-directory={{SNC_BACKEND_LOCATION}}
+directory={{SNC_BACKEND_DEPLOY_LOCATION}}
 stdout_logfile={{SNC_BACKEND_DATA_LOCATION}}/logs/bluenet.log
 redirect_stderr=true
 stdout_logfile_backup=1

--- a/meta-senic/recipes-hub/hub-configuration/files/supervisor_device_discovery.conf
+++ b/meta-senic/recipes-hub/hub-configuration/files/supervisor_device_discovery.conf
@@ -1,9 +1,9 @@
 [program:device_discovery]
-command = /usr/bin/device_discovery -c {{SNC_BACKEND_LOCATION}}/production.ini
+command = /usr/bin/device_discovery -c {{SNC_BACKEND_DEPLOY_LOCATION}}/production.ini
 environment=LC_ALL={{SNC_LOCALE}}, LANG={{SNC_LOCALE}}
 autostart=true
 autorestart=true
-directory={{SNC_BACKEND_LOCATION}}
+directory={{SNC_BACKEND_DEPLOY_LOCATION}}
 stdout_logfile={{SNC_BACKEND_DATA_LOCATION}}/logs/device_discovery.log
 stdout_logfile_backup=1
 stdout_capture_maxbytes=50MB

--- a/meta-senic/recipes-hub/hub-configuration/files/supervisor_netwatch.conf
+++ b/meta-senic/recipes-hub/hub-configuration/files/supervisor_netwatch.conf
@@ -2,7 +2,7 @@
 command = /usr/bin/netwatch start -vv
 autostart=true
 autorestart=true
-directory={{SNC_BACKEND_LOCATION}}
+directory={{SNC_BACKEND_DEPLOY_LOCATION}}
 stdout_logfile={{SNC_BACKEND_DATA_LOCATION}}/logs/netwatch.log
 redirect_stderr=true
 stdout_logfile_backup=1

--- a/meta-senic/recipes-hub/hub-configuration/files/supervisor_nuimo_app.conf
+++ b/meta-senic/recipes-hub/hub-configuration/files/supervisor_nuimo_app.conf
@@ -1,6 +1,6 @@
 [program:nuimo_app]
-command = /usr/bin/nuimo_app -c {{SNC_BACKEND_LOCATION}}/production.ini
-directory={{SNC_BACKEND_LOCATION}}
+command = /usr/bin/nuimo_app -c {{SNC_BACKEND_DEPLOY_LOCATION}}/production.ini
+directory={{SNC_BACKEND_DEPLOY_LOCATION}}
 autostart=false
 autorestart=true
 stdout_logfile={{SNC_BACKEND_DATA_LOCATION}}/logs/nuimo_app.log

--- a/meta-senic/recipes-hub/hub-configuration/files/supervisor_senic_hub.conf
+++ b/meta-senic/recipes-hub/hub-configuration/files/supervisor_senic_hub.conf
@@ -1,6 +1,6 @@
 [program:senic_hub]
-command = /usr/bin/pserve {{SNC_BACKEND_LOCATION}}/production.ini
-directory={{SNC_BACKEND_LOCATION}}
+command = /usr/bin/pserve {{SNC_BACKEND_DEPLOY_LOCATION}}/production.ini
+directory={{SNC_BACKEND_DEPLOY_LOCATION}}
 autostart=true
 autorestart=true
 stdout_logfile={{SNC_BACKEND_DATA_LOCATION}}/logs/senic_hub.log

--- a/meta-senic/recipes-hub/hub-configuration/hub-configuration_0.1.0.bb
+++ b/meta-senic/recipes-hub/hub-configuration/hub-configuration_0.1.0.bb
@@ -42,7 +42,7 @@ do_install() {
     install -m 0755 -o ${SNC_BUILD_USER} -g ${SNC_RUNTIME_USER} -d ${D}${SNC_BACKEND_DEPLOY_LOCATION}
     install -m 0755 -o ${SNC_RUNTIME_USER} -g ${SNC_RUNTIME_USER} -d ${D}${SNC_BACKEND_DATA_LOCATION}
     install -m 0755 -o ${SNC_RUNTIME_USER} -g ${SNC_RUNTIME_USER} -d ${D}${SNC_BACKEND_DATA_LOCATION}/logs
-    install -m 0755 -o ${SNC_BUILD_USER} -g ${SNC_RUNTIME_USER} ${WORKDIR}/production.ini ${D}${SNC_BACKEND_LOCATION}/production.ini
+    install -m 0755 -o ${SNC_BUILD_USER} -g ${SNC_RUNTIME_USER} ${WORKDIR}/production.ini ${D}${SNC_BACKEND_DEPLOY_LOCATION}/production.ini
     install -m 0755 -d ${D}${SNC_HASS_DATA_LOCATION}
 
     # configure supervisor processes


### PR DESCRIPTION
`SNC_BACKEND_LOCATION` is the same as `SNC_BACKEND_DEPLOY_LOCATION`