### PR TITLE
Add reset button functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,3 +82,9 @@ However, you can also connect via a serial console (i.e. ``screen /dev/tty.usbse
 
 
 -    nmcli dev wifi con <SSID> password <PASSWORD> ifname wlan0
+
+
+Hardware
+--------
+
+The reset button is connected to pin 10 on the GPIO connector. When the button is pressed the GPIO pin is pulled to GND, otherwise it's pulled to SYS_3.3V.

--- a/meta-senic/recipes-core/base-files/base-files/senic_button.py
+++ b/meta-senic/recipes-core/base-files/base-files/senic_button.py
@@ -40,15 +40,17 @@ def execute_and_log(command):
 
 
 def on_short_press(press_duration):
-    daemon.logger.info("Reset button held for %0.2f seconds: REBOOT" %
-                       press_duration)
+    daemon.logger.info(
+            "Reset button held for %0.2f seconds: REBOOT" %
+            press_duration)
     execute_and_log('/sbin/reboot')
     exit()
 
 
 def on_long_press(press_duration):
-    daemon.logger.info("Reset button held for %0.2f seconds: FACTORY RESET" %
-                       press_duration)
+    daemon.logger.info(
+            "Reset button held for %0.2f seconds: FACTORY RESET" %
+            press_duration)
     execute_and_log('/etc/init.d/supervisor stop')
     execute_and_log('/usr/bin/nmcli connection del bluenet')
     execute_and_log('/sbin/reboot')

--- a/meta-senic/recipes-core/base-files/base-files/senic_button.py
+++ b/meta-senic/recipes-core/base-files/base-files/senic_button.py
@@ -20,13 +20,13 @@ MAX_DURATION = 30   # Ignore button presses longer than this many seconds
 
 def init_gpio():
     if not os.path.exists(PIN_PATH):
-        write_once(GPIO_PATH + 'export', GPIO_PIN)
-    write_once(PIN_PATH + 'direction', 'in')
-    write_once(PIN_PATH + 'active_low', '1')
-    write_once(PIN_PATH + 'edge', 'both')
+        write_file(GPIO_PATH + 'export', GPIO_PIN)
+    write_file(PIN_PATH + 'direction', 'in')
+    write_file(PIN_PATH + 'active_low', '1')
+    write_file(PIN_PATH + 'edge', 'both')
 
 
-def write_once(path, value):
+def write_file(path, value):
     with open(path, 'w') as f:
         f.write(value)
 

--- a/meta-senic/recipes-core/base-files/base-files/senic_button.py
+++ b/meta-senic/recipes-core/base-files/base-files/senic_button.py
@@ -44,7 +44,6 @@ def on_short_press(press_duration):
             "Reset button held for %0.2f seconds: REBOOT" %
             press_duration)
     execute_and_log('/sbin/reboot')
-    exit()
 
 
 def on_long_press(press_duration):
@@ -52,7 +51,6 @@ def on_long_press(press_duration):
             "Reset button held for %0.2f seconds: FACTORY RESET" %
             press_duration)
     execute_and_log('/usr/bin/nmcli connection del bluenet')
-    exit()
 
 
 def listen_for_button_presses():

--- a/meta-senic/recipes-core/base-files/base-files/senic_button.py
+++ b/meta-senic/recipes-core/base-files/base-files/senic_button.py
@@ -9,9 +9,6 @@ import os
 LOG_NAME = 'senic_button'
 DAEMON_PID = '/var/run/senic_button.pid'
 
-# The reset button should be connected to pin 10 on the GPIO connector.
-# When the button is pressed the pin will be pulled to GND, otherwise it's
-# pulled to SYS_3.3V.
 GPIO_PIN = '199'
 GPIO_PATH = '/sys/class/gpio/'
 PIN_PATH = GPIO_PATH + 'gpio' + GPIO_PIN + '/'

--- a/meta-senic/recipes-core/base-files/base-files/senic_button.py
+++ b/meta-senic/recipes-core/base-files/base-files/senic_button.py
@@ -27,8 +27,8 @@ def init_gpio():
 
 
 def write_file(path, value):
-    with open(path, 'w') as f:
-        f.write(value)
+    with open(path, 'w') as file_descriptor:
+        file_descriptor.write(value)
 
 
 def execute_and_log(command):
@@ -58,16 +58,16 @@ def on_long_press(press_duration):
 def listen_for_button_presses():
     init_gpio()
 
-    f = open(PIN_PATH + 'value', 'r')
-    po = select.poll()
-    po.register(f, select.POLLPRI)
+    pin_value = open(PIN_PATH + 'value', 'r')
+    pin_event = select.poll()
+    pin_event.register(pin_value, select.POLLPRI)
 
     start = 0
     while True:
-        po.poll(None)  # Blocking until button state change
+        pin_event.poll(None)  # Blocking until button state change
 
-        f.seek(0)
-        state = f.read()
+        pin_value.seek(0)
+        state = pin_value.read()
 
         if state == "1\n":
             start = time.time()

--- a/meta-senic/recipes-core/base-files/base-files/senic_button.py
+++ b/meta-senic/recipes-core/base-files/base-files/senic_button.py
@@ -13,9 +13,8 @@ GPIO_PIN = '199'
 GPIO_PATH = '/sys/class/gpio/'
 PIN_PATH = GPIO_PATH + 'gpio' + GPIO_PIN + '/'
 
-DEBOUNCE = 0.05     # Ignore repeated button presses for the first 50ms
-FACTORY_RESET = 10  # Factory reset after this many seconds
-MAX_DURATION = 30   # Ignore button presses longer than this many seconds
+FACTORY_RESET = 3   # Factory reset after this many seconds
+MAX_DURATION = 20   # Ignore button presses longer than this many seconds
 
 
 def init_gpio():
@@ -39,14 +38,7 @@ def execute_and_log(command):
             daemon.logger.info("    " + line)
 
 
-def on_short_press(press_duration):
-    daemon.logger.info(
-            "Reset button held for %0.2f seconds: REBOOT" %
-            press_duration)
-    execute_and_log('/sbin/reboot')
-
-
-def on_long_press(press_duration):
+def on_press(press_duration):
     daemon.logger.info(
             "Reset button held for %0.2f seconds: FACTORY RESET" %
             press_duration)
@@ -73,11 +65,9 @@ def listen_for_button_presses():
             end = time.time()
             press_duration = end - start
 
-            if press_duration > DEBOUNCE and press_duration < FACTORY_RESET:
-                on_short_press(press_duration)
-            elif press_duration >= FACTORY_RESET and \
-                    press_duration <= MAX_DURATION:
-                on_long_press(press_duration)
+            if press_duration >= FACTORY_RESET and \
+               press_duration < MAX_DURATION:
+                on_press(press_duration)
 
 
 daemon = Daemonize(app=LOG_NAME,

--- a/meta-senic/recipes-core/base-files/base-files/senic_button.py
+++ b/meta-senic/recipes-core/base-files/base-files/senic_button.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+
+import commands
+from daemonize import Daemonize
+import select
+import time
+import os
+
+LOG_NAME = 'senic_button'
+DAEMON_PID = '/var/run/senic_button.pid'
+
+# The reset button should be connected to pin 10 on the GPIO connector.
+# When the button is pressed the pin will be pulled to GND, otherwise it's
+# pulled to SYS_3.3V.
+GPIO_PIN = '199'
+GPIO_PATH = '/sys/class/gpio/'
+PIN_PATH = GPIO_PATH + 'gpio' + GPIO_PIN + '/'
+
+DEBOUNCE = 0.05     # Ignore repeated button presses for the first 50ms
+FACTORY_RESET = 10  # Factory reset after this many seconds
+MAX_DURATION = 30   # Ignore button presses longer than this many seconds
+
+
+def init_gpio():
+    if not os.path.exists(PIN_PATH):
+        write_once(GPIO_PATH + 'export', GPIO_PIN)
+    write_once(PIN_PATH + 'direction', 'in')
+    write_once(PIN_PATH + 'active_low', '1')
+    write_once(PIN_PATH + 'edge', 'both')
+
+
+def write_once(path, value):
+    with open(path, 'w') as f:
+        f.write(value)
+
+
+def execute_and_log(command):
+    daemon.logger.info("Executing: %s", command)
+    output = commands.getstatusoutput(command)
+    if output[1]:
+        for line in output[1].split('\n'):
+            daemon.logger.info("    " + line)
+
+
+def on_short_press(press_duration):
+    daemon.logger.info("Reset button held for %0.2f seconds: REBOOT" %
+                       press_duration)
+    execute_and_log('/sbin/reboot')
+    exit()
+
+
+def on_long_press(press_duration):
+    daemon.logger.info("Reset button held for %0.2f seconds: FACTORY RESET" %
+                       press_duration)
+    execute_and_log('/etc/init.d/supervisor stop')
+    execute_and_log('/usr/bin/nmcli connection del bluenet')
+    execute_and_log('/sbin/reboot')
+    exit()
+
+
+def listen_for_button_presses():
+    init_gpio()
+
+    f = open(PIN_PATH + 'value', 'r')
+    po = select.poll()
+    po.register(f, select.POLLPRI)
+
+    start = 0
+    while True:
+        po.poll(None)  # Blocking until button state change
+
+        f.seek(0)
+        state = f.read()
+
+        if state == "1\n":
+            start = time.time()
+        else:
+            end = time.time()
+            press_duration = end - start
+
+            if press_duration > DEBOUNCE and press_duration < FACTORY_RESET:
+                on_short_press(press_duration)
+            elif press_duration >= FACTORY_RESET and \
+                    press_duration <= MAX_DURATION:
+                on_long_press(press_duration)
+
+
+daemon = Daemonize(app=LOG_NAME,
+                   pid=DAEMON_PID,
+                   action=listen_for_button_presses)
+
+daemon.start()

--- a/meta-senic/recipes-core/base-files/base-files/senic_button.py
+++ b/meta-senic/recipes-core/base-files/base-files/senic_button.py
@@ -51,9 +51,7 @@ def on_long_press(press_duration):
     daemon.logger.info(
             "Reset button held for %0.2f seconds: FACTORY RESET" %
             press_duration)
-    execute_and_log('/etc/init.d/supervisor stop')
     execute_and_log('/usr/bin/nmcli connection del bluenet')
-    execute_and_log('/sbin/reboot')
     exit()
 
 

--- a/meta-senic/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/meta-senic/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -1,9 +1,11 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://motd_senic"
+SRC_URI += "file://senic_button.py"
 
 do_install_append() {
 
 	# The extra files need to go in the respective directories
 	install -m 0755 ${WORKDIR}/motd_senic	${D}${sysconfdir}/motd_senic
+	install -m 0755 ${WORKDIR}/senic_button.py ${D}${sbindir}/senic_button.py
 }

--- a/meta-senic/recipes-core/images/senic-os.bb
+++ b/meta-senic/recipes-core/images/senic-os.bb
@@ -21,6 +21,7 @@ IMAGE_INSTALL = " \
   ntp \
   python \
   python-supervisor \
+  python-daemonize \
   python3 \
   python3-asn1crypto \
   python3-cffi \

--- a/meta-senic/recipes-core/initscripts/initscripts/senic_button
+++ b/meta-senic/recipes-core/initscripts/initscripts/senic_button
@@ -1,0 +1,49 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:        senic_button
+# Required-Start:  $syslog
+# Required-Stop:   $syslog
+# Default-Start:   2 3 4 5
+# Default-Stop:
+# Short-Description: Listens to button presses and reboots or facotry resets the device
+### END INIT INFO
+
+PATH=/sbin:/bin:/usr/bin:/usr/sbin
+
+NAME=senic_button
+DAEMON=/usr/sbin/senic_button.py
+PIDFILE=/var/run/senic_button.pid
+
+# Source function library.
+. /etc/init.d/functions
+
+startdaemon(){
+	echo -n "Starting $NAME: "
+	start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --startas $DAEMON "$@"
+	echo "done"
+}
+stopdaemon(){
+	echo -n "Stopping $NAME: "
+	start-stop-daemon --stop --quiet --oknodo -p $PIDFILE
+	echo "done"
+}
+
+case "$1" in
+  start)
+	startdaemon
+	;;
+  stop)
+  stopdaemon
+	;;
+  restart)
+	stopdaemon
+	startdaemon
+	;;
+  *)
+	echo "Usage: ntpd { start | stop | restart }" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/meta-senic/recipes-core/initscripts/initscripts_1.0.bbappend
+++ b/meta-senic/recipes-core/initscripts/initscripts_1.0.bbappend
@@ -20,6 +20,9 @@ do_install_append() {
   update-rc.d -r ${D} senic_update_motd start 98 5 .
   update-rc.d -r ${D} networkmanager start 91 5 .
 
+  # Add filesystem expander script to runlevel S after root fs is mounted rw
+  update-rc.d -r ${D} fs_expander start 99 S .
+
   # Add button listener daemon after logging has been started
   update-rc.d -r ${D} senic_button start 22 5 .
 

--- a/meta-senic/recipes-core/initscripts/initscripts_1.0.bbappend
+++ b/meta-senic/recipes-core/initscripts/initscripts_1.0.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += "file://update_motd.sh"
 SRC_URI += "file://networkmanager"
 SRC_URI += "file://fs_expander"
+SRC_URI += "file://senic_button"
 
 # Tests needed only on debug release
 SRC_URI += "file://esd_test.sh"
@@ -10,6 +11,7 @@ SRC_URI += "file://esd_test.sh"
 do_install_append() {
 
   # Install initscripts into /etc/init.d
+  install -m 0755 ${WORKDIR}/senic_button ${D}${sysconfdir}/init.d/senic_button
   install -m 0755 ${WORKDIR}/fs_expander  ${D}${sysconfdir}/init.d/fs_expander
   install -m 0755 ${WORKDIR}/update_motd.sh ${D}${sysconfdir}/init.d/senic_update_motd
   install -m 0755 ${WORKDIR}/networkmanager ${D}${sysconfdir}/init.d/networkmanager
@@ -18,8 +20,8 @@ do_install_append() {
   update-rc.d -r ${D} senic_update_motd start 98 5 .
   update-rc.d -r ${D} networkmanager start 91 5 .
 
-  # Add filesystem expander script to runlevel S after root fs is mounted rw
-  update-rc.d -r ${D} fs_expander start 99 S .
+  # Add button listener daemon after logging has been started
+  update-rc.d -r ${D} senic_button start 22 5 .
 
   # Tests needed only on debug release
   # install -m 0755 ${WORKDIR}/esd_test.sh  ${D}${sysconfdir}/init.d/senic_esd_test

--- a/meta-senic/recipes-devtools/python/python-daemonize.inc
+++ b/meta-senic/recipes-devtools/python/python-daemonize.inc
@@ -1,0 +1,9 @@
+SUMMARY = "Library to enable your code run as a daemon process on Unix-like systems"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit pypi
+
+SRC_URI[md5sum] = "6759005b12dfeea0d4305f8536b4b0c2"
+
+

--- a/meta-senic/recipes-hub/hub-installation/hub-installation_0.1.0.bb
+++ b/meta-senic/recipes-hub/hub-installation/hub-installation_0.1.0.bb
@@ -3,6 +3,7 @@ DESCRIPTION = "\
 Creates a virtualenv and install the required python eggs"
 DEPENDS_${PN} = "\
   python-supervisor \
+  python-daemonize \
   python3 \
   python3-asn1crypto \
   python3-cffi \


### PR DESCRIPTION
The Senic hub has one physical button which is used for rebooting the
device as well as resetting it to factory defaults.

The button is connected to the MCU's GPIO pin 10. When the button is open
(default state) the pin is pulled up to 3.3V. By pressing the button the pin
is pulled to GND.

The button handler daemon is started via an init script and will differentiate
between two types of input:

  short press - when the button is pressed and held for at least 50ms (but no
                longer than 9 seconds), a soft reboot is performed

  long press - when the button is pressed and held between 10 and 30 seconds,
               the supervisor daemon is stopped, bluenet wifi settings are
               cleared and a soft reboot is performed

The daemon will log debugging info to syslog (logs normally land in
/var/log/messages prefixed with "senic_button").

The daemon could be started earlier during boot-up, but this way we would lose
the ability to log debug info to disk. If we choose to do so logging directly
to the TTY serial console would still be an option.