### PR TITLE
use git instead of ssh for senic-os-uboot

### DIFF
--- a/meta-senic/recipes-bsp/u-boot/u-boot-senic_2017.03.bb
+++ b/meta-senic/recipes-bsp/u-boot/u-boot-senic_2017.03.bb
@@ -8,7 +8,7 @@ DEPENDS += "dtc-native"
 COMPATIBLE_MACHINE = "(senic-hub-beta|senic-hub)"
 
 SRCBRANCH = "senic/v2017.03"
-SRC_URI = "git://git@github.com/getsenic/senic-os-uboot.git;protocol=ssh;branch=${SRCBRANCH}; \
+SRC_URI = "git://github.com/getsenic/senic-os-uboot.git;protocol=git;branch=${SRCBRANCH}; \
 	   file://boot.cmd \
 	   "
 


### PR DESCRIPTION
This PR makes possible to clone senic-os-uboot if you don't have a ssh keys

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsenic/senic-os/33)
<!-- Reviewable:end -->
