### PR TITLE
Add recipe for `cornice=2.3.0` and `cornice-swagger`

### DIFF
--- a/meta-senic/recipes-core/images/senic-os.bb
+++ b/meta-senic/recipes-core/images/senic-os.bb
@@ -32,6 +32,7 @@ IMAGE_INSTALL = " \
   python3-colander \
   python3-contextlib2 \
   python3-cornice \
+  python3-cornice-swagger \
   python3-cryptography \
   python3-cryptoyaml \
   python3-dbus \

--- a/meta-senic/recipes-devtools/python/python3-cornice-swagger_0.5.1.bb
+++ b/meta-senic/recipes-devtools/python/python3-cornice-swagger_0.5.1.bb
@@ -2,7 +2,9 @@ SUMMARY = "Generate swagger from a Cornice application."
 HOMEPAGE = "https://cornices.github.io/cornice.ext.swagger/"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
+PYPI_PACKAGE = "cornice_swagger"
 
 inherit setuptools3
 inherit pypi
 SRC_URI[md5sum] = "6f7849e6d52ac94584fea621d10210cc"
+

--- a/meta-senic/recipes-devtools/python/python3-cornice_2.3.0.bb
+++ b/meta-senic/recipes-devtools/python/python3-cornice_2.3.0.bb
@@ -5,4 +5,4 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=a5bfa0b879709dc2d0908ff07efa5b4d"
 
 inherit setuptools3
 inherit pypi
-SRC_URI[md5sum] = "b53eb7561148459659762b029efbd04c"
+SRC_URI[md5sum] = "1b7238088fd86676bdf2d9ed4cbad4dd"

--- a/meta-senic/recipes-devtools/python/python3-cornice_swagger_0.5.1.bb
+++ b/meta-senic/recipes-devtools/python/python3-cornice_swagger_0.5.1.bb
@@ -1,0 +1,8 @@
+SUMMARY = "Generate swagger from a Cornice application."
+HOMEPAGE = "https://cornices.github.io/cornice.ext.swagger/"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
+
+inherit setuptools3
+inherit pypi
+SRC_URI[md5sum] = "6f7849e6d52ac94584fea621d10210cc"


### PR DESCRIPTION
Closes #47 
Added recipes for cornice=2.3.0 & cornice_swagger, with proper checksums for url & Licenses. 
There appears to be some problem with cornice 2.4.0. So, it's better to stick with 2.3.0 for now.

The next step would be to host the packages on pypi.senic.com