### PR TITLE
Log all exceptions to Sentry

### DIFF
--- a/meta-senic/conf/local.conf.sample
+++ b/meta-senic/conf/local.conf.sample
@@ -70,3 +70,7 @@ SNC_DEVPI_INDEX = "root/pypi"
 # Set up our own ntp servers for production!
 # Use this only for beta testing.
 SNC_NTP_HOST = "pool.ntp.org"
+
+# Sentry endpoint for exception logging
+# TODO: provide a way for the user to opt-in for the production release!
+SNC_SENTRY_DSN = "https://2601699ddeb64448bd4499a57a8887b8:9db76c84b3ca415290bf952197ab9739@sentry.io/179864"

--- a/meta-senic/recipes-hub/hub-configuration/files/production.ini
+++ b/meta-senic/recipes-hub/hub-configuration/files/production.ini
@@ -28,6 +28,7 @@ hub_ip_address = 0.0.0.0
 
 [filter:raven]
 use = egg:raven#raven
+dsn = {{SNC_SENTRY_DSN}}
 include_paths = senic_hub
 
 [pipeline:main]
@@ -49,8 +50,8 @@ level = INFO
 handlers = console, sentry
 
 [logger_sentry]
-level = WARN
-handlers = console
+level = INFO
+handlers = sentry
 qualname = sentry.errors
 propagate = 0
 
@@ -62,8 +63,8 @@ formatter = generic
 
 [handler_sentry]
 class = raven.handlers.logging.SentryHandler
-args = ()
-level = WARNING
+args = ('{{SNC_SENTRY_DSN}}',)
+level = INFO
 formatter = generic
 
 [formatter_generic]


### PR DESCRIPTION
There is still some weird bitbake caching problem. The SNC_SENTRY_DSN variable doesn't get substituted with the actual value.