### PR TITLE
Fix supervisorctl import error on senic-os

### DIFF
--- a/meta-senic/recipes-core/images/senic-os-dev.bb
+++ b/meta-senic/recipes-core/images/senic-os-dev.bb
@@ -10,8 +10,6 @@ IMAGE_INSTALL += " \
 	curl \
 	bash \
 	bash-completion \
-	python-pip \
-	python3-pip \
 	python3-debugger \
 	iperf3 \ 
 	stress \

--- a/meta-senic/recipes-core/images/senic-os.bb
+++ b/meta-senic/recipes-core/images/senic-os.bb
@@ -51,6 +51,7 @@ IMAGE_INSTALL = " \
   python3-pastedeploy \
   python3-pbkdf2 \
   python3-phue \
+  python-pip \
   python3-pip \
   python3-plaster \
   python3-pygobject \


### PR DESCRIPTION
Update base `senic-os` image to include `python-pip` & `python3-pip`. This
removes the need to include them in `senic-os-dev`.

Resolves: #81 