### PR TITLE
meta-senic: Add patches to enable ethernet support

### DIFF
--- a/meta-senic/recipes-kernel/linux/files/0001-net-stmmac-snps-dwmac-mdio-MDIOs-are-automatically-r.patch
+++ b/meta-senic/recipes-kernel/linux/files/0001-net-stmmac-snps-dwmac-mdio-MDIOs-are-automatically-r.patch
@@ -1,0 +1,38 @@
+From 58e9800d8386a0dd00eea8ecca3d933fc071dbe1 Mon Sep 17 00:00:00 2001
+From: Corentin Labbe <clabbe.montjoie@gmail.com>
+Date: Tue, 24 Oct 2017 19:57:12 +0200
+Subject: [PATCH] net: stmmac: snps, dwmac-mdio MDIOs are automatically
+ registered
+
+stmmac bindings docs said that its mdio node must have
+compatible = "snps,dwmac-mdio";
+Since dwmac-sun8i does not have any good reasons to not doing it, all
+their MDIO node must have it.
+
+Since these compatible is automatically registered, dwmac-sun8i compatible
+does not need to be in need_mdio_ids.
+
+Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+index 195eb7e71473..05f122b8424a 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+@@ -318,10 +318,6 @@ static int stmmac_dt_phy(struct plat_stmmacenet_data *plat,
+ 	bool mdio = true;
+ 	static const struct of_device_id need_mdio_ids[] = {
+ 		{ .compatible = "snps,dwc-qos-ethernet-4.10" },
+-		{ .compatible = "allwinner,sun8i-a83t-emac" },
+-		{ .compatible = "allwinner,sun8i-h3-emac" },
+-		{ .compatible = "allwinner,sun8i-v3s-emac" },
+-		{ .compatible = "allwinner,sun50i-a64-emac" },
+ 		{},
+ 	};
+ 
+-- 
+2.11.0
+

--- a/meta-senic/recipes-kernel/linux/files/0002-net-stmmac-dwmac-sun8i-Handle-integrated-external-MD.patch
+++ b/meta-senic/recipes-kernel/linux/files/0002-net-stmmac-dwmac-sun8i-Handle-integrated-external-MD.patch
@@ -1,0 +1,513 @@
+From 35a49aed701722deed911adf005c34e621e3a1b7 Mon Sep 17 00:00:00 2001
+From: Corentin Labbe <clabbe.montjoie@gmail.com>
+Date: Tue, 24 Oct 2017 19:57:13 +0200
+Subject: [PATCH] net: stmmac: dwmac-sun8i: Handle integrated/external MDIOs
+
+The Allwinner H3 SoC have two distinct MDIO bus, only one could be
+active at the same time.
+The selection of the active MDIO bus are done via some bits in the EMAC
+register of the system controller.
+
+This patch implement this MDIO switch via a custom MDIO-mux.
+
+Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/stmicro/stmmac/Kconfig       |   1 +
+ drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c | 353 ++++++++++++++--------
+ 2 files changed, 224 insertions(+), 130 deletions(-)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
+index 97035766c291..e28c0d2c58e9 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
++++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
+@@ -159,6 +159,7 @@ config DWMAC_SUN8I
+ 	tristate "Allwinner sun8i GMAC support"
+ 	default ARCH_SUNXI
+ 	depends on OF && (ARCH_SUNXI || COMPILE_TEST)
++	select MDIO_BUS_MUX
+ 	---help---
+ 	  Support for Allwinner H3 A83T A64 EMAC ethernet controllers.
+ 
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
+index 39c2122a4f26..b3eb344bb158 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
+@@ -17,6 +17,7 @@
+ #include <linux/clk.h>
+ #include <linux/io.h>
+ #include <linux/iopoll.h>
++#include <linux/mdio-mux.h>
+ #include <linux/mfd/syscon.h>
+ #include <linux/module.h>
+ #include <linux/of_device.h>
+@@ -41,14 +42,14 @@
+  *				This value is used for disabling properly EMAC
+  *				and used as a good starting value in case of the
+  *				boot process(uboot) leave some stuff.
+- * @internal_phy:		Does the MAC embed an internal PHY
++ * @soc_has_internal_phy:	Does the MAC embed an internal PHY
+  * @support_mii:		Does the MAC handle MII
+  * @support_rmii:		Does the MAC handle RMII
+  * @support_rgmii:		Does the MAC handle RGMII
+  */
+ struct emac_variant {
+ 	u32 default_syscon_value;
+-	int internal_phy;
++	bool soc_has_internal_phy;
+ 	bool support_mii;
+ 	bool support_rmii;
+ 	bool support_rgmii;
+@@ -61,7 +62,8 @@ struct emac_variant {
+  * @rst_ephy:	reference to the optional EPHY reset for the internal PHY
+  * @variant:	reference to the current board variant
+  * @regmap:	regmap for using the syscon
+- * @use_internal_phy: Does the current PHY choice imply using the internal PHY
++ * @internal_phy_powered: Does the internal PHY is enabled
++ * @mux_handle:	Internal pointer used by mdio-mux lib
+  */
+ struct sunxi_priv_data {
+ 	struct clk *tx_clk;
+@@ -70,12 +72,13 @@ struct sunxi_priv_data {
+ 	struct reset_control *rst_ephy;
+ 	const struct emac_variant *variant;
+ 	struct regmap *regmap;
+-	bool use_internal_phy;
++	bool internal_phy_powered;
++	void *mux_handle;
+ };
+ 
+ static const struct emac_variant emac_variant_h3 = {
+ 	.default_syscon_value = 0x58000,
+-	.internal_phy = PHY_INTERFACE_MODE_MII,
++	.soc_has_internal_phy = true,
+ 	.support_mii = true,
+ 	.support_rmii = true,
+ 	.support_rgmii = true
+@@ -83,20 +86,20 @@ static const struct emac_variant emac_variant_h3 = {
+ 
+ static const struct emac_variant emac_variant_v3s = {
+ 	.default_syscon_value = 0x38000,
+-	.internal_phy = PHY_INTERFACE_MODE_MII,
++	.soc_has_internal_phy = true,
+ 	.support_mii = true
+ };
+ 
+ static const struct emac_variant emac_variant_a83t = {
+ 	.default_syscon_value = 0,
+-	.internal_phy = 0,
++	.soc_has_internal_phy = false,
+ 	.support_mii = true,
+ 	.support_rgmii = true
+ };
+ 
+ static const struct emac_variant emac_variant_a64 = {
+ 	.default_syscon_value = 0,
+-	.internal_phy = 0,
++	.soc_has_internal_phy = false,
+ 	.support_mii = true,
+ 	.support_rmii = true,
+ 	.support_rgmii = true
+@@ -195,6 +198,9 @@ static const struct emac_variant emac_variant_a64 = {
+ #define H3_EPHY_LED_POL		BIT(17) /* 1: active low, 0: active high */
+ #define H3_EPHY_SHUTDOWN	BIT(16) /* 1: shutdown, 0: power up */
+ #define H3_EPHY_SELECT		BIT(15) /* 1: internal PHY, 0: external PHY */
++#define H3_EPHY_MUX_MASK	(H3_EPHY_SHUTDOWN | H3_EPHY_SELECT)
++#define DWMAC_SUN8I_MDIO_MUX_INTERNAL_ID	1
++#define DWMAC_SUN8I_MDIO_MUX_EXTERNAL_ID	2
+ 
+ /* H3/A64 specific bits */
+ #define SYSCON_RMII_EN		BIT(13) /* 1: enable RMII (overrides EPIT) */
+@@ -634,6 +640,159 @@ static int sun8i_dwmac_reset(struct stmmac_priv *priv)
+ 	return 0;
+ }
+ 
++/* Search in mdio-mux node for internal PHY node and get its clk/reset */
++static int get_ephy_nodes(struct stmmac_priv *priv)
++{
++	struct sunxi_priv_data *gmac = priv->plat->bsp_priv;
++	struct device_node *mdio_mux, *iphynode;
++	struct device_node *mdio_internal;
++	int ret;
++
++	mdio_mux = of_get_child_by_name(priv->device->of_node, "mdio-mux");
++	if (!mdio_mux) {
++		dev_err(priv->device, "Cannot get mdio-mux node\n");
++		return -ENODEV;
++	}
++
++	mdio_internal = of_find_compatible_node(mdio_mux, NULL,
++						"allwinner,sun8i-h3-mdio-internal");
++	if (!mdio_internal) {
++		dev_err(priv->device, "Cannot get internal_mdio node\n");
++		return -ENODEV;
++	}
++
++	/* Seek for internal PHY */
++	for_each_child_of_node(mdio_internal, iphynode) {
++		gmac->ephy_clk = of_clk_get(iphynode, 0);
++		if (IS_ERR(gmac->ephy_clk))
++			continue;
++		gmac->rst_ephy = of_reset_control_get_exclusive(iphynode, NULL);
++		if (IS_ERR(gmac->rst_ephy)) {
++			ret = PTR_ERR(gmac->rst_ephy);
++			if (ret == -EPROBE_DEFER)
++				return ret;
++			continue;
++		}
++		dev_info(priv->device, "Found internal PHY node\n");
++		return 0;
++	}
++	return -ENODEV;
++}
++
++static int sun8i_dwmac_power_internal_phy(struct stmmac_priv *priv)
++{
++	struct sunxi_priv_data *gmac = priv->plat->bsp_priv;
++	int ret;
++
++	if (gmac->internal_phy_powered) {
++		dev_warn(priv->device, "Internal PHY already powered\n");
++		return 0;
++	}
++
++	dev_info(priv->device, "Powering internal PHY\n");
++	ret = clk_prepare_enable(gmac->ephy_clk);
++	if (ret) {
++		dev_err(priv->device, "Cannot enable internal PHY\n");
++		return ret;
++	}
++
++	/* Make sure the EPHY is properly reseted, as U-Boot may leave
++	 * it at deasserted state, and thus it may fail to reset EMAC.
++	 */
++	reset_control_assert(gmac->rst_ephy);
++
++	ret = reset_control_deassert(gmac->rst_ephy);
++	if (ret) {
++		dev_err(priv->device, "Cannot deassert internal phy\n");
++		clk_disable_unprepare(gmac->ephy_clk);
++		return ret;
++	}
++
++	gmac->internal_phy_powered = true;
++
++	return 0;
++}
++
++static int sun8i_dwmac_unpower_internal_phy(struct sunxi_priv_data *gmac)
++{
++	if (!gmac->internal_phy_powered)
++		return 0;
++
++	clk_disable_unprepare(gmac->ephy_clk);
++	reset_control_assert(gmac->rst_ephy);
++	gmac->internal_phy_powered = false;
++	return 0;
++}
++
++/* MDIO multiplexing switch function
++ * This function is called by the mdio-mux layer when it thinks the mdio bus
++ * multiplexer needs to switch.
++ * 'current_child' is the current value of the mux register
++ * 'desired_child' is the value of the 'reg' property of the target child MDIO
++ * node.
++ * The first time this function is called, current_child == -1.
++ * If current_child == desired_child, then the mux is already set to the
++ * correct bus.
++ */
++static int mdio_mux_syscon_switch_fn(int current_child, int desired_child,
++				     void *data)
++{
++	struct stmmac_priv *priv = data;
++	struct sunxi_priv_data *gmac = priv->plat->bsp_priv;
++	u32 reg, val;
++	int ret = 0;
++	bool need_power_ephy = false;
++
++	if (current_child ^ desired_child) {
++		regmap_read(gmac->regmap, SYSCON_EMAC_REG, &reg);
++		switch (desired_child) {
++		case DWMAC_SUN8I_MDIO_MUX_INTERNAL_ID:
++			dev_info(priv->device, "Switch mux to internal PHY");
++			val = (reg & ~H3_EPHY_MUX_MASK) | H3_EPHY_SELECT;
++
++			need_power_ephy = true;
++			break;
++		case DWMAC_SUN8I_MDIO_MUX_EXTERNAL_ID:
++			dev_info(priv->device, "Switch mux to external PHY");
++			val = (reg & ~H3_EPHY_MUX_MASK) | H3_EPHY_SHUTDOWN;
++			need_power_ephy = false;
++			break;
++		default:
++			dev_err(priv->device, "Invalid child ID %x\n",
++				desired_child);
++			return -EINVAL;
++		}
++		regmap_write(gmac->regmap, SYSCON_EMAC_REG, val);
++		if (need_power_ephy) {
++			ret = sun8i_dwmac_power_internal_phy(priv);
++			if (ret)
++				return ret;
++		} else {
++			sun8i_dwmac_unpower_internal_phy(gmac);
++		}
++		/* After changing syscon value, the MAC need reset or it will
++		 * use the last value (and so the last PHY set).
++		 */
++		ret = sun8i_dwmac_reset(priv);
++	}
++	return ret;
++}
++
++static int sun8i_dwmac_register_mdio_mux(struct stmmac_priv *priv)
++{
++	int ret;
++	struct device_node *mdio_mux;
++	struct sunxi_priv_data *gmac = priv->plat->bsp_priv;
++
++	mdio_mux = of_get_child_by_name(priv->device->of_node, "mdio-mux");
++	if (!mdio_mux)
++		return -ENODEV;
++
++	ret = mdio_mux_init(priv->device, mdio_mux, mdio_mux_syscon_switch_fn,
++			    &gmac->mux_handle, priv, priv->mii);
++	return ret;
++}
++
+ static int sun8i_dwmac_set_syscon(struct stmmac_priv *priv)
+ {
+ 	struct sunxi_priv_data *gmac = priv->plat->bsp_priv;
+@@ -648,35 +807,25 @@ static int sun8i_dwmac_set_syscon(struct stmmac_priv *priv)
+ 			 "Current syscon value is not the default %x (expect %x)\n",
+ 			 val, reg);
+ 
+-	if (gmac->variant->internal_phy) {
+-		if (!gmac->use_internal_phy) {
+-			/* switch to external PHY interface */
+-			reg &= ~H3_EPHY_SELECT;
+-		} else {
+-			reg |= H3_EPHY_SELECT;
+-			reg &= ~H3_EPHY_SHUTDOWN;
+-			dev_dbg(priv->device, "Select internal_phy %x\n", reg);
+-
+-			if (of_property_read_bool(priv->plat->phy_node,
+-						  "allwinner,leds-active-low"))
+-				reg |= H3_EPHY_LED_POL;
+-			else
+-				reg &= ~H3_EPHY_LED_POL;
+-
+-			/* Force EPHY xtal frequency to 24MHz. */
+-			reg |= H3_EPHY_CLK_SEL;
+-
+-			ret = of_mdio_parse_addr(priv->device,
+-						 priv->plat->phy_node);
+-			if (ret < 0) {
+-				dev_err(priv->device, "Could not parse MDIO addr\n");
+-				return ret;
+-			}
+-			/* of_mdio_parse_addr returns a valid (0 ~ 31) PHY
+-			 * address. No need to mask it again.
+-			 */
+-			reg |= ret << H3_EPHY_ADDR_SHIFT;
++	if (gmac->variant->soc_has_internal_phy) {
++		if (of_property_read_bool(priv->plat->phy_node,
++					  "allwinner,leds-active-low"))
++			reg |= H3_EPHY_LED_POL;
++		else
++			reg &= ~H3_EPHY_LED_POL;
++
++		/* Force EPHY xtal frequency to 24MHz. */
++		reg |= H3_EPHY_CLK_SEL;
++
++		ret = of_mdio_parse_addr(priv->device, priv->plat->phy_node);
++		if (ret < 0) {
++			dev_err(priv->device, "Could not parse MDIO addr\n");
++			return ret;
+ 		}
++		/* of_mdio_parse_addr returns a valid (0 ~ 31) PHY
++		 * address. No need to mask it again.
++		 */
++		reg |= 1 << H3_EPHY_ADDR_SHIFT;
+ 	}
+ 
+ 	if (!of_property_read_u32(node, "allwinner,tx-delay-ps", &val)) {
+@@ -746,81 +895,21 @@ static void sun8i_dwmac_unset_syscon(struct sunxi_priv_data *gmac)
+ 	regmap_write(gmac->regmap, SYSCON_EMAC_REG, reg);
+ }
+ 
+-static int sun8i_dwmac_power_internal_phy(struct stmmac_priv *priv)
++static void sun8i_dwmac_exit(struct platform_device *pdev, void *priv)
+ {
+-	struct sunxi_priv_data *gmac = priv->plat->bsp_priv;
+-	int ret;
+-
+-	if (!gmac->use_internal_phy)
+-		return 0;
+-
+-	ret = clk_prepare_enable(gmac->ephy_clk);
+-	if (ret) {
+-		dev_err(priv->device, "Cannot enable ephy\n");
+-		return ret;
+-	}
+-
+-	/* Make sure the EPHY is properly reseted, as U-Boot may leave
+-	 * it at deasserted state, and thus it may fail to reset EMAC.
+-	 */
+-	reset_control_assert(gmac->rst_ephy);
++	struct sunxi_priv_data *gmac = priv;
+ 
+-	ret = reset_control_deassert(gmac->rst_ephy);
+-	if (ret) {
+-		dev_err(priv->device, "Cannot deassert ephy\n");
+-		clk_disable_unprepare(gmac->ephy_clk);
+-		return ret;
++	if (gmac->variant->soc_has_internal_phy) {
++		/* sun8i_dwmac_exit could be called with mdiomux uninit */
++		if (gmac->mux_handle)
++			mdio_mux_uninit(gmac->mux_handle);
++		if (gmac->internal_phy_powered)
++			sun8i_dwmac_unpower_internal_phy(gmac);
+ 	}
+ 
+-	return 0;
+-}
+-
+-static int sun8i_dwmac_unpower_internal_phy(struct sunxi_priv_data *gmac)
+-{
+-	if (!gmac->use_internal_phy)
+-		return 0;
+-
+-	clk_disable_unprepare(gmac->ephy_clk);
+-	reset_control_assert(gmac->rst_ephy);
+-	return 0;
+-}
+-
+-/* sun8i_power_phy() - Activate the PHY:
+- * In case of error, no need to call sun8i_unpower_phy(),
+- * it will be called anyway by sun8i_dwmac_exit()
+- */
+-static int sun8i_power_phy(struct stmmac_priv *priv)
+-{
+-	int ret;
+-
+-	ret = sun8i_dwmac_power_internal_phy(priv);
+-	if (ret)
+-		return ret;
+-
+-	ret = sun8i_dwmac_set_syscon(priv);
+-	if (ret)
+-		return ret;
+-
+-	/* After changing syscon value, the MAC need reset or it will use
+-	 * the last value (and so the last PHY set.
+-	 */
+-	ret = sun8i_dwmac_reset(priv);
+-	if (ret)
+-		return ret;
+-	return 0;
+-}
+-
+-static void sun8i_unpower_phy(struct sunxi_priv_data *gmac)
+-{
+ 	sun8i_dwmac_unset_syscon(gmac);
+-	sun8i_dwmac_unpower_internal_phy(gmac);
+-}
+-
+-static void sun8i_dwmac_exit(struct platform_device *pdev, void *priv)
+-{
+-	struct sunxi_priv_data *gmac = priv;
+ 
+-	sun8i_unpower_phy(gmac);
++	reset_control_put(gmac->rst_ephy);
+ 
+ 	clk_disable_unprepare(gmac->tx_clk);
+ 
+@@ -849,7 +938,7 @@ static struct mac_device_info *sun8i_dwmac_setup(void *ppriv)
+ 	if (!mac)
+ 		return NULL;
+ 
+-	ret = sun8i_power_phy(priv);
++	ret = sun8i_dwmac_set_syscon(priv);
+ 	if (ret)
+ 		return NULL;
+ 
+@@ -889,6 +978,8 @@ static int sun8i_dwmac_probe(struct platform_device *pdev)
+ 	struct sunxi_priv_data *gmac;
+ 	struct device *dev = &pdev->dev;
+ 	int ret;
++	struct stmmac_priv *priv;
++	struct net_device *ndev;
+ 
+ 	ret = stmmac_get_platform_resources(pdev, &stmmac_res);
+ 	if (ret)
+@@ -932,29 +1023,6 @@ static int sun8i_dwmac_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	plat_dat->interface = of_get_phy_mode(dev->of_node);
+-	if (plat_dat->interface == gmac->variant->internal_phy) {
+-		dev_info(&pdev->dev, "Will use internal PHY\n");
+-		gmac->use_internal_phy = true;
+-		gmac->ephy_clk = of_clk_get(plat_dat->phy_node, 0);
+-		if (IS_ERR(gmac->ephy_clk)) {
+-			ret = PTR_ERR(gmac->ephy_clk);
+-			dev_err(&pdev->dev, "Cannot get EPHY clock: %d\n", ret);
+-			return -EINVAL;
+-		}
+-
+-		gmac->rst_ephy = of_reset_control_get(plat_dat->phy_node, NULL);
+-		if (IS_ERR(gmac->rst_ephy)) {
+-			ret = PTR_ERR(gmac->rst_ephy);
+-			if (ret == -EPROBE_DEFER)
+-				return ret;
+-			dev_err(&pdev->dev, "No EPHY reset control found %d\n",
+-				ret);
+-			return -EINVAL;
+-		}
+-	} else {
+-		dev_info(&pdev->dev, "Will use external PHY\n");
+-		gmac->use_internal_phy = false;
+-	}
+ 
+ 	/* platform data specifying hardware features and callbacks.
+ 	 * hardware features were copied from Allwinner drivers.
+@@ -973,9 +1041,34 @@ static int sun8i_dwmac_probe(struct platform_device *pdev)
+ 
+ 	ret = stmmac_dvr_probe(&pdev->dev, plat_dat, &stmmac_res);
+ 	if (ret)
+-		sun8i_dwmac_exit(pdev, plat_dat->bsp_priv);
++		goto dwmac_exit;
++
++	ndev = dev_get_drvdata(&pdev->dev);
++	priv = netdev_priv(ndev);
++	/* The mux must be registered after parent MDIO
++	 * so after stmmac_dvr_probe()
++	 */
++	if (gmac->variant->soc_has_internal_phy) {
++		ret = get_ephy_nodes(priv);
++		if (ret)
++			goto dwmac_exit;
++		ret = sun8i_dwmac_register_mdio_mux(priv);
++		if (ret) {
++			dev_err(&pdev->dev, "Failed to register mux\n");
++			goto dwmac_mux;
++		}
++	} else {
++		ret = sun8i_dwmac_reset(priv);
++		if (ret)
++			goto dwmac_exit;
++	}
+ 
+ 	return ret;
++dwmac_mux:
++	sun8i_dwmac_unset_syscon(gmac);
++dwmac_exit:
++	sun8i_dwmac_exit(pdev, plat_dat->bsp_priv);
++return ret;
+ }
+ 
+ static const struct of_device_id sun8i_dwmac_match[] = {
+-- 
+2.11.0
+

--- a/meta-senic/recipes-kernel/linux/files/0003-net-stmmac-sun8i-Restore-the-compatibles.patch
+++ b/meta-senic/recipes-kernel/linux/files/0003-net-stmmac-sun8i-Restore-the-compatibles.patch
@@ -1,0 +1,40 @@
+From b16b70866792f3e405cd05e56dab62e74f9ac7f0 Mon Sep 17 00:00:00 2001
+From: Corentin Labbe <clabbe.montjoie@gmail.com>
+Date: Tue, 24 Oct 2017 19:57:14 +0200
+Subject: [PATCH] net: stmmac: sun8i: Restore the compatibles
+
+The original dwmac-sun8i DT bindings have some issue on how to handle
+integrated PHY and was reverted in last RC of 4.13.
+But now we have a solution so we need to get back that was reverted.
+
+This patch restore compatibles about dwmac-sun8i
+This reverts commit ad4540cc5aa3 ("net: stmmac: sun8i: Remove the compatibles")
+
+Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
+index b3eb344bb158..e5ff734d4f9b 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-sun8i.c
+@@ -1072,6 +1072,14 @@ return ret;
+ }
+ 
+ static const struct of_device_id sun8i_dwmac_match[] = {
++	{ .compatible = "allwinner,sun8i-h3-emac",
++		.data = &emac_variant_h3 },
++	{ .compatible = "allwinner,sun8i-v3s-emac",
++		.data = &emac_variant_v3s },
++	{ .compatible = "allwinner,sun8i-a83t-emac",
++		.data = &emac_variant_a83t },
++	{ .compatible = "allwinner,sun50i-a64-emac",
++		.data = &emac_variant_a64 },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(of, sun8i_dwmac_match);
+-- 
+2.11.0
+

--- a/meta-senic/recipes-kernel/linux/files/0004-arm-dts-sunxi-h3-h5-Restore-EMAC-changes.patch
+++ b/meta-senic/recipes-kernel/linux/files/0004-arm-dts-sunxi-h3-h5-Restore-EMAC-changes.patch
@@ -1,0 +1,59 @@
+From 37a7f82af40aef6f7195093cbd98d724bf645e3c Mon Sep 17 00:00:00 2001
+From: Corentin Labbe <clabbe.montjoie@gmail.com>
+Date: Tue, 31 Oct 2017 09:19:10 +0100
+Subject: [PATCH] arm: dts: sunxi: h3/h5: Restore EMAC changes
+
+The original dwmac-sun8i DT bindings have some issue on how to handle
+integrated PHY and was reverted in last RC of 4.13.
+But now we have a solution so we need to get back that was reverted.
+
+This patch restore sunxi-h3-h5.dtsi
+This reverts partially commit fe45174b72ae ("arm: dts: sunxi: Revert EMAC changes")
+
+Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+Acked-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: Maxime Ripard <maxime.ripard@free-electrons.com>
+---
+ arch/arm/boot/dts/sunxi-h3-h5.dtsi | 26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index 11240a8313c2..d38282b9e5d4 100644
+--- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+@@ -391,6 +391,32 @@
+ 			clocks = <&osc24M>;
+ 		};
+ 
++		emac: ethernet@1c30000 {
++			compatible = "allwinner,sun8i-h3-emac";
++			syscon = <&syscon>;
++			reg = <0x01c30000 0x10000>;
++			interrupts = <GIC_SPI 82 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "macirq";
++			resets = <&ccu RST_BUS_EMAC>;
++			reset-names = "stmmaceth";
++			clocks = <&ccu CLK_BUS_EMAC>;
++			clock-names = "stmmaceth";
++			#address-cells = <1>;
++			#size-cells = <0>;
++			status = "disabled";
++
++			mdio: mdio {
++				#address-cells = <1>;
++				#size-cells = <0>;
++				int_mii_phy: ethernet-phy@1 {
++					compatible = "ethernet-phy-ieee802.3-c22";
++					reg = <1>;
++					clocks = <&ccu CLK_BUS_EPHY>;
++					resets = <&ccu RST_BUS_EPHY>;
++				};
++			};
++		};
++
+ 		spi0: spi@01c68000 {
+ 			compatible = "allwinner,sun8i-h3-spi";
+ 			reg = <0x01c68000 0x1000>;
+-- 
+2.11.0
+

--- a/meta-senic/recipes-kernel/linux/files/0005-ARM-dts-sunxi-h3-h5-represent-the-mdio-switch-used-b.patch
+++ b/meta-senic/recipes-kernel/linux/files/0005-ARM-dts-sunxi-h3-h5-represent-the-mdio-switch-used-b.patch
@@ -1,0 +1,64 @@
+From 54fd684fe14c3f7d94edc88194fd149939a65fa8 Mon Sep 17 00:00:00 2001
+From: Corentin Labbe <clabbe.montjoie@gmail.com>
+Date: Tue, 31 Oct 2017 09:19:11 +0100
+Subject: [PATCH] ARM: dts: sunxi: h3/h5: represent the mdio switch used by
+ sun8i-h3-emac
+
+Since dwmac-sun8i could use either an integrated PHY or an external PHY
+(which could be at same MDIO address), we need to represent this selection
+by a MDIO switch.
+
+Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+Acked-by: Florian Fainelli <f.fainelli@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Maxime Ripard <maxime.ripard@free-electrons.com>
+---
+ arch/arm/boot/dts/sunxi-h3-h5.dtsi | 31 +++++++++++++++++++++++++++----
+ 1 file changed, 27 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index d38282b9e5d4..2721b39c1875 100644
+--- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+@@ -408,11 +408,34 @@
+ 			mdio: mdio {
+ 				#address-cells = <1>;
+ 				#size-cells = <0>;
+-				int_mii_phy: ethernet-phy@1 {
+-					compatible = "ethernet-phy-ieee802.3-c22";
++				compatible = "snps,dwmac-mdio";
++			};
++
++			mdio-mux {
++				compatible = "allwinner,sun8i-h3-mdio-mux";
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				mdio-parent-bus = <&mdio>;
++				/* Only one MDIO is usable at the time */
++				internal_mdio: mdio@1 {
++					compatible = "allwinner,sun8i-h3-mdio-internal";
+ 					reg = <1>;
+-					clocks = <&ccu CLK_BUS_EPHY>;
+-					resets = <&ccu RST_BUS_EPHY>;
++					#address-cells = <1>;
++					#size-cells = <0>;
++
++					int_mii_phy: ethernet-phy@1 {
++						compatible = "ethernet-phy-ieee802.3-c22";
++						reg = <1>;
++						clocks = <&ccu CLK_BUS_EPHY>;
++						resets = <&ccu RST_BUS_EPHY>;
++					};
++				};
++
++				external_mdio: mdio@2 {
++					reg = <2>;
++					#address-cells = <1>;
++					#size-cells = <0>;
+ 				};
+ 			};
+ 		};
+-- 
+2.11.0
+

--- a/meta-senic/recipes-kernel/linux/files/0006-ARM-dts-sunxi-Restore-EMAC-changes-boards.patch
+++ b/meta-senic/recipes-kernel/linux/files/0006-ARM-dts-sunxi-Restore-EMAC-changes-boards.patch
@@ -1,0 +1,315 @@
+From 0d2a6cef165abb1d7519646881647eea4cd22665 Mon Sep 17 00:00:00 2001
+From: Corentin Labbe <clabbe.montjoie@gmail.com>
+Date: Tue, 31 Oct 2017 09:19:12 +0100
+Subject: [PATCH] ARM: dts: sunxi: Restore EMAC changes (boards)
+
+The original dwmac-sun8i DT bindings have some issue on how to handle
+integrated PHY and was reverted in last RC of 4.13.
+But now we have a solution so we need to get back that was reverted.
+
+This patch restore all boards DT about dwmac-sun8i
+This reverts partially commit fe45174b72ae ("arm: dts: sunxi: Revert EMAC changes")
+
+Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+Acked-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: Maxime Ripard <maxime.ripard@free-electrons.com>
+---
+ arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts |  9 +++++++
+ arch/arm/boot/dts/sun8i-h3-bananapi-m2-plus.dts   | 19 +++++++++++++++
+ arch/arm/boot/dts/sun8i-h3-nanopi-m1-plus.dts     | 29 +++++++++++++++++++++++
+ arch/arm/boot/dts/sun8i-h3-nanopi-neo.dts         |  7 ++++++
+ arch/arm/boot/dts/sun8i-h3-orangepi-2.dts         |  8 +++++++
+ arch/arm/boot/dts/sun8i-h3-orangepi-one.dts       |  8 +++++++
+ arch/arm/boot/dts/sun8i-h3-orangepi-pc-plus.dts   |  5 ++++
+ arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts        |  8 +++++++
+ arch/arm/boot/dts/sun8i-h3-orangepi-plus.dts      | 22 +++++++++++++++++
+ arch/arm/boot/dts/sun8i-h3-orangepi-plus2e.dts    | 16 +++++++++++++
+ 10 files changed, 131 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+index b1502df7b509..6713d0f2b3f4 100644
+--- a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
++++ b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+@@ -56,6 +56,8 @@
+ 
+ 	aliases {
+ 		serial0 = &uart0;
++		/* ethernet0 is the H3 emac, defined in sun8i-h3.dtsi */
++		ethernet0 = &emac;
+ 		ethernet1 = &xr819;
+ 	};
+ 
+@@ -102,6 +104,13 @@
+ 	status = "okay";
+ };
+ 
++&emac {
++	phy-handle = <&int_mii_phy>;
++	phy-mode = "mii";
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
+ &mmc0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&mmc0_pins_a>;
+diff --git a/arch/arm/boot/dts/sun8i-h3-bananapi-m2-plus.dts b/arch/arm/boot/dts/sun8i-h3-bananapi-m2-plus.dts
+index a337af1de322..3f95d806355b 100644
+--- a/arch/arm/boot/dts/sun8i-h3-bananapi-m2-plus.dts
++++ b/arch/arm/boot/dts/sun8i-h3-bananapi-m2-plus.dts
+@@ -52,6 +52,7 @@
+ 	compatible = "sinovoip,bpi-m2-plus", "allwinner,sun8i-h3";
+ 
+ 	aliases {
++		ethernet0 = &emac;
+ 		serial0 = &uart0;
+ 		serial1 = &uart1;
+ 	};
+@@ -114,6 +115,24 @@
+ 	status = "okay";
+ };
+ 
++&emac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&emac_rgmii_pins>;
++	phy-supply = <&reg_gmac_3v3>;
++	phy-handle = <&ext_rgmii_phy>;
++	phy-mode = "rgmii";
++
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
++&external_mdio {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <0>;
++	};
++};
++
+ &ir {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&ir_pins_a>;
+diff --git a/arch/arm/boot/dts/sun8i-h3-nanopi-m1-plus.dts b/arch/arm/boot/dts/sun8i-h3-nanopi-m1-plus.dts
+index 8ddd1b2cc097..17affbe3b658 100644
+--- a/arch/arm/boot/dts/sun8i-h3-nanopi-m1-plus.dts
++++ b/arch/arm/boot/dts/sun8i-h3-nanopi-m1-plus.dts
+@@ -45,6 +45,16 @@
+ / {
+ 	model = "FriendlyArm NanoPi M1 Plus";
+ 	compatible = "friendlyarm,nanopi-m1-plus", "allwinner,sun8i-h3";
++
++	reg_gmac_3v3: gmac-3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "gmac-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <100000>;
++		enable-active-high;
++		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>;
++	};
+ };
+ 
+ &ehci1 {
+@@ -55,6 +65,25 @@
+ 	status = "okay";
+ };
+ 
++&emac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&emac_rgmii_pins>;
++	phy-supply = <&reg_gmac_3v3>;
++	phy-handle = <&ext_rgmii_phy>;
++	phy-mode = "rgmii";
++
++	allwinner,leds-active-low;
++
++	status = "okay";
++};
++
++&external_mdio {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <7>;
++	};
++};
++
+ &ohci1 {
+ 	status = "okay";
+ };
+diff --git a/arch/arm/boot/dts/sun8i-h3-nanopi-neo.dts b/arch/arm/boot/dts/sun8i-h3-nanopi-neo.dts
+index 8d2cc6e9a03f..78f6c24952dd 100644
+--- a/arch/arm/boot/dts/sun8i-h3-nanopi-neo.dts
++++ b/arch/arm/boot/dts/sun8i-h3-nanopi-neo.dts
+@@ -46,3 +46,10 @@
+ 	model = "FriendlyARM NanoPi NEO";
+ 	compatible = "friendlyarm,nanopi-neo", "allwinner,sun8i-h3";
+ };
++
++&emac {
++	phy-handle = <&int_mii_phy>;
++	phy-mode = "mii";
++	allwinner,leds-active-low;
++	status = "okay";
++};
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-2.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-2.dts
+index 8ff71b1bb45b..17cdeae19c6f 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-2.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-2.dts
+@@ -54,6 +54,7 @@
+ 	aliases {
+ 		serial0 = &uart0;
+ 		/* ethernet0 is the H3 emac, defined in sun8i-h3.dtsi */
++		ethernet0 = &emac;
+ 		ethernet1 = &rtl8189;
+ 	};
+ 
+@@ -117,6 +118,13 @@
+ 	status = "okay";
+ };
+ 
++&emac {
++	phy-handle = <&int_mii_phy>;
++	phy-mode = "mii";
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
+ &ir {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&ir_pins_a>;
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts
+index 5fea430e0eb1..6880268e8b87 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts
+@@ -52,6 +52,7 @@
+ 	compatible = "xunlong,orangepi-one", "allwinner,sun8i-h3";
+ 
+ 	aliases {
++		ethernet0 = &emac;
+ 		serial0 = &uart0;
+ 	};
+ 
+@@ -97,6 +98,13 @@
+ 	status = "okay";
+ };
+ 
++&emac {
++	phy-handle = <&int_mii_phy>;
++	phy-mode = "mii";
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
+ &mmc0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&mmc0_pins_a>, <&mmc0_cd_pin>;
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-pc-plus.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-pc-plus.dts
+index 8b93f5c781a7..a10281b455f5 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-pc-plus.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-pc-plus.dts
+@@ -53,6 +53,11 @@
+ 	};
+ };
+ 
++&emac {
++	/* LEDs changed to active high on the plus */
++	/delete-property/ allwinner,leds-active-low;
++};
++
+ &mmc1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&mmc1_pins_a>;
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
+index 1a044b17d6c6..998b60f8d295 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
+@@ -52,6 +52,7 @@
+ 	compatible = "xunlong,orangepi-pc", "allwinner,sun8i-h3";
+ 
+ 	aliases {
++		ethernet0 = &emac;
+ 		serial0 = &uart0;
+ 	};
+ 
+@@ -113,6 +114,13 @@
+ 	status = "okay";
+ };
+ 
++&emac {
++	phy-handle = <&int_mii_phy>;
++	phy-mode = "mii";
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
+ &ir {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&ir_pins_a>;
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-plus.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-plus.dts
+index 828ae7a526d9..3002c025e187 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-plus.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-plus.dts
+@@ -47,6 +47,10 @@
+ 	model = "Xunlong Orange Pi Plus / Plus 2";
+ 	compatible = "xunlong,orangepi-plus", "allwinner,sun8i-h3";
+ 
++	aliases {
++		ethernet0 = &emac;
++	};
++
+ 	reg_gmac_3v3: gmac-3v3 {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "gmac-3v3";
+@@ -74,6 +78,24 @@
+ 	status = "okay";
+ };
+ 
++&emac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&emac_rgmii_pins>;
++	phy-supply = <&reg_gmac_3v3>;
++	phy-handle = <&ext_rgmii_phy>;
++	phy-mode = "rgmii";
++
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
++&external_mdio {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <0>;
++	};
++};
++
+ &mmc2 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&mmc2_8bit_pins>;
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-plus2e.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-plus2e.dts
+index 97920b12a944..6dbf7b2e0c13 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-plus2e.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-plus2e.dts
+@@ -61,3 +61,19 @@
+ 		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>; /* PD6 */
+ 	};
+ };
++
++&emac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&emac_rgmii_pins>;
++	phy-supply = <&reg_gmac_3v3>;
++	phy-handle = <&ext_rgmii_phy>;
++	phy-mode = "rgmii";
++	status = "okay";
++};
++
++&external_mdio {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <1>;
++	};
++};
+-- 
+2.11.0
+

--- a/meta-senic/recipes-kernel/linux/files/0007-ARM-dts-sun8i-h3-Add-senic-hub-dts.patch
+++ b/meta-senic/recipes-kernel/linux/files/0007-ARM-dts-sun8i-h3-Add-senic-hub-dts.patch
@@ -1,9 +1,39 @@
+From 0fd183773fc76af8ab4a031e37e9dd552f8239a6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Myl=C3=A8ne=20Josserand?=
+ <mylene.josserand@free-electrons.com>
+Date: Tue, 23 Jan 2018 15:47:53 +0100
+Subject: [PATCH] ARM: dts: sun8i-h3: Add senic-hub dts
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add device tree for Senic Hub.
+
+Signed-off-by: Mylène Josserand <mylene.josserand@free-electrons.com>
+---
+ arch/arm/boot/dts/Makefile               |   1 +
+ arch/arm/boot/dts/sun8i-h3-senic-hub.dts | 211 +++++++++++++++++++++++++++++++
+ 2 files changed, 212 insertions(+)
+ create mode 100644 arch/arm/boot/dts/sun8i-h3-senic-hub.dts
+
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index eff87a344566..8d362957f661 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -930,6 +930,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+ 	sun8i-h3-orangepi-pc-plus.dtb \
+ 	sun8i-h3-orangepi-plus.dtb \
+ 	sun8i-h3-orangepi-plus2e.dtb \
++	sun8i-h3-senic-hub.dtb \
+ 	sun8i-r16-bananapi-m2m.dtb \
+ 	sun8i-r16-parrot.dtb \
+ 	sun8i-v3s-licheepi-zero.dtb \
 diff --git a/arch/arm/boot/dts/sun8i-h3-senic-hub.dts b/arch/arm/boot/dts/sun8i-h3-senic-hub.dts
 new file mode 100644
-index 000000000000..ac93c1fdc595
+index 000000000000..e43221e9238e
 --- /dev/null
 +++ b/arch/arm/boot/dts/sun8i-h3-senic-hub.dts
-@@ -0,0 +1,204 @@
+@@ -0,0 +1,211 @@
 +/*
 + * Copyright (C) 2017 Aravinth Panch <aravinth@senic.com>
 + *
@@ -121,6 +151,13 @@ index 000000000000..ac93c1fdc595
 +	status = "okay";
 +};
 +
++&emac {
++	phy-handle = <&int_mii_phy>;
++	phy-mode = "mii";
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
 +&ohci1 {
 +	status = "okay";
 +};
@@ -193,7 +230,7 @@ index 000000000000..ac93c1fdc595
 +
 +&pio {
 +    uart2_pins_rts_cts: uart2_rts_cts {
-+        pins = "PA2", "PA3";  
++        pins = "PA2", "PA3";
 +        function = "uart2";
 +    };
 +};
@@ -208,3 +245,6 @@ index 000000000000..ac93c1fdc595
 +	/* USB VBUS is always on */
 +	status = "okay";
 +};
+-- 
+2.11.0
+

--- a/meta-senic/recipes-kernel/linux/linux_git.bb
+++ b/meta-senic/recipes-kernel/linux/linux_git.bb
@@ -20,7 +20,13 @@ SRCREV_pn-${PN} = "bebc6082da0a9f5d47a1ea2edc099bf671058bd4"
 
 SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;protocol=git;branch=master \
         file://defconfig \
-	file://0001-add-senic-hub-dts.patch \
+	file://0001-net-stmmac-snps-dwmac-mdio-MDIOs-are-automatically-r.patch \
+	file://0002-net-stmmac-dwmac-sun8i-Handle-integrated-external-MD.patch \
+	file://0003-net-stmmac-sun8i-Restore-the-compatibles.patch \
+	file://0004-arm-dts-sunxi-h3-h5-Restore-EMAC-changes.patch \
+	file://0005-ARM-dts-sunxi-h3-h5-represent-the-mdio-switch-used-b.patch \
+	file://0006-ARM-dts-sunxi-Restore-EMAC-changes-boards.patch \
+	file://0007-ARM-dts-sun8i-h3-Add-senic-hub-dts.patch \
         "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Hello everyone,

As discussed by email, you will find this pull-request that adds ethernet support for senic hub.
I tested all the patches in a kernel repository, outside Yocto Project.
I did not tried the update of this recipe  but I think that the patch is correct otherwise, do not hesitate to update/fix it.

Thank you in advance,
Best regards,
Mylène